### PR TITLE
Update to the Zig 0.15.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ See information on [contributing](./CONTRIBUTING.md).
 
 ## Building from Source
 
-Before you begin, ensure that the Zig compiler version [**0.14.1**](https://ziglang.org/download/) is installed on your workstation.
+Before you begin, ensure that the Zig compiler version [**0.15.2**](https://ziglang.org/download/) is installed on your workstation.
 
 The build process is quite straightforward:
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,7 +4,7 @@
 
     .fingerprint = 0xcd2c4ccb5b1efab1, // Changing this has security and trust implications.
 
-    .minimum_zig_version = "0.14.1",
+    .minimum_zig_version = "0.15.2",
 
     .dependencies = .{
         .bootboot_bin = .{

--- a/src/kernel/arch/x86-64/dev/lapic_timer.zig
+++ b/src/kernel/arch/x86-64/dev/lapic_timer.zig
@@ -44,7 +44,7 @@ pub fn init() !void {
     try evalTimerFrequency();
 
     const device = try dev.getKernelDriver()
-        .addDevice(dev.nameOf(device_name), null);
+        .addDevice(dev.Name.init(device_name), null);
     errdefer dev.removeDevice(device);
 
     timer.init(

--- a/src/kernel/arch/x86-64/dev/rtc_cmos.zig
+++ b/src/kernel/arch/x86-64/dev/rtc_cmos.zig
@@ -78,7 +78,7 @@ pub inline fn getObject() *Clock {
 fn initDevice(self: *const dev.Driver) !void {
     regs = try RtcRegs.init();
 
-    device = try self.addDevice(dev.nameOf(device_name), null);
+    device = try self.addDevice(dev.Name.init(device_name), null);
     errdefer dev.removeDevice(device);
 
     clock = try dev.obj.new(Clock);

--- a/src/kernel/arch/x86-64/intr/apic.zig
+++ b/src/kernel/arch/x86-64/intr/apic.zig
@@ -12,9 +12,7 @@ const pic = @import("pic.zig");
 const regs = @import("../regs.zig");
 const smp = @import("../../../smp.zig");
 
-const c = @cImport(
-    @cInclude("cpuid.h")
-);
+const c = @cImport(@cInclude("cpuid.h"));
 
 pub const ioapic = @import("ioapic.zig");
 pub const lapic = @import("lapic.zig");
@@ -32,7 +30,7 @@ pub const Madt = extern struct {
         };
 
         type: Type,
-        length: u8
+        length: u8,
     };
 
     pub const ProcLapic = extern struct {
@@ -55,7 +53,7 @@ pub const Madt = extern struct {
         bus: u8,
         irq: u8,
         gsi: u32 align(1),
-        flags: u16 align(1), 
+        flags: u16 align(1),
     };
 
     header: acpi.SdtHeader,
@@ -75,8 +73,7 @@ pub const Madt = extern struct {
 
         const end_addr = @intFromPtr(&self._entries) + self.header.length;
 
-        while (@intFromPtr(entry) < end_addr)
-        : (entry = @ptrFromInt(@intFromPtr(entry) + entry.length)) {
+        while (@intFromPtr(entry) < end_addr) : (entry = @ptrFromInt(@intFromPtr(entry) + entry.length)) {
             // Don`t trust hardware, avoid infinity loop
             if (entry.length == 0) break;
 
@@ -88,32 +85,11 @@ pub const Madt = extern struct {
 };
 
 pub const Interrupt = struct {
-    pub const DeliveryMode = enum(u3) {
-        fixed = 0,
-        lowest_priority = 1,
-        smi = 2,
-
-        nmi = 4,
-        init = 5,
-
-        ext_init = 7
-    };
-    pub const DestinationMode = enum(u1) {
-        physical = 0,
-        logical = 1
-    };
-    pub const DeliveryStatus = enum(u1) {
-        relaxed = 0,
-        waiting = 1
-    };
-    pub const Polarity = enum(u1) {
-        active_high = 0,
-        active_low = 1
-    };
-    pub const TriggerMode = enum(u1) {
-        edge = 0,
-        level = 1
-    };
+    pub const DeliveryMode = enum(u3) { fixed = 0, lowest_priority = 1, smi = 2, nmi = 4, init = 5, ext_init = 7 };
+    pub const DestinationMode = enum(u1) { physical = 0, logical = 1 };
+    pub const DeliveryStatus = enum(u1) { relaxed = 0, waiting = 1 };
+    pub const Polarity = enum(u1) { active_high = 0, active_low = 1 };
+    pub const TriggerMode = enum(u1) { edge = 0, level = 1 };
 };
 
 const Msi = struct {
@@ -206,11 +182,11 @@ fn bindIrq(irq: *const intr.Irq) void {
         .dest = cpuIdxToApicId(irq.vector.cpu),
         .pin_polarity = switch (irq.trigger_mode) {
             .level_low => .active_low,
-            else => .active_high
+            else => .active_high,
         },
-        .trig_mode = switch(irq.trigger_mode) {
+        .trig_mode = switch (irq.trigger_mode) {
             .edge => .edge,
-            else => .level
+            else => .level,
         },
         .mask = 1,
     });
@@ -246,11 +222,11 @@ fn configMsi(msi: *intr.Msi, idx: u8, trigger_mode: intr.TriggerMode) void {
         .delv_mode = .fixed,
         .pin_polarity = switch (trigger_mode) {
             .level_low => .active_low,
-            else => .active_high
+            else => .active_high,
         },
         .trig_mode = switch (trigger_mode) {
             .edge => .edge,
-            else => .level
+            else => .level,
         }
     };
 
@@ -261,8 +237,5 @@ fn configMsi(msi: *intr.Msi, idx: u8, trigger_mode: intr.TriggerMode) void {
         arch.intr.intr_gate_flags,
     );
 
-    msi.message = .{
-        .address = @as(u32, @bitCast(address)),
-        .data = @bitCast(data)
-    };
+    msi.message = .{ .address = @as(u32, @bitCast(address)), .data = @bitCast(data) };
 }

--- a/src/kernel/arch/x86-64/intr/lapic.zig
+++ b/src/kernel/arch/x86-64/intr/lapic.zig
@@ -47,11 +47,7 @@ pub const LvtTimer = packed struct {
     rsrvd_1: u3 = 0,
     mask: u1 = 0,
 
-    timer_mode: enum(u2) {
-        once = 0b00,
-        periodic = 0b01,
-        tsc_deadline = 0b10
-    },
+    timer_mode: enum(u2) { once = 0b00, periodic = 0b01, tsc_deadline = 0b10 },
 
     rsrvd_2: u13 = 0,
 };

--- a/src/kernel/arch/x86-64/intr/pic.zig
+++ b/src/kernel/arch/x86-64/intr/pic.zig
@@ -4,15 +4,8 @@ const dev = @import("../../../dev.zig");
 const io = dev.io;
 const intr = dev.intr;
 
-pub const Regs = enum(u1) {
-    command = 0x0,
-    data = 0x1
-};
-
-pub const Chip = enum(u8) {
-    master = 0x20,
-    slave = 0xa0
-};
+pub const Regs = enum(u1) { command = 0x0, data = 0x1 };
+pub const Chip = enum(u8) { master = 0x20, slave = 0xa0 };
 
 pub fn init() !void {
     _ = io.request("PIC Master", @intFromEnum(Chip.master), 0x2, .io_ports) orelse return error.IoBusy;
@@ -20,10 +13,7 @@ pub fn init() !void {
 }
 
 pub fn chip() intr.Chip {
-    return .{
-        .name = "8259 PIC",
-        .ops = undefined
-    };
+    return .{ .name = "8259 PIC", .ops = undefined };
 }
 
 pub inline fn disable() void {

--- a/src/kernel/arch/x86-64/io.zig
+++ b/src/kernel/arch/x86-64/io.zig
@@ -2,24 +2,39 @@
 
 /// Write a byte into a I\O port.
 pub inline fn outb(port: u16, byte: u8) void {
-    asm volatile("outb %[d],%[p]"::[d]"{al}"(byte),[p]"{dx}"(port));
+    asm volatile ("outb %[d],%[p]"
+        :
+        : [d] "{al}" (byte),
+          [p] "{dx}" (port),
+    );
 }
 
 /// Write a word into a I\O port.
 pub inline fn outw(port: u16, word: u16) void {
-    asm volatile("outw %[d],%[p]"::[d]"{ax}"(word),[p]"{dx}"(port));
+    asm volatile ("outw %[d],%[p]"
+        :
+        : [d] "{ax}" (word),
+          [p] "{dx}" (port),
+    );
 }
 
 /// Write a double word into a I\O port.
 pub inline fn outl(port: u16, dword: u32) void {
-    asm volatile("outl %[d],%[p]"::[d]"{eax}"(dword),[p]"{dx}"(port));
+    asm volatile ("outl %[d],%[p]"
+        :
+        : [d] "{eax}" (dword),
+          [p] "{dx}" (port),
+    );
 }
 
 /// Read a byte from I\O port.
 pub inline fn inb(port: u16) u8 {
     var res: u8 = undefined;
 
-    asm volatile("inb %[p],%[r]":[r]"={al}"(res):[p]"{dx}"(port));
+    asm volatile ("inb %[p],%[r]"
+        : [r] "={al}" (res),
+        : [p] "{dx}" (port),
+    );
     return res;
 }
 
@@ -27,7 +42,10 @@ pub inline fn inb(port: u16) u8 {
 pub inline fn inw(port: u16) u16 {
     var res: u16 = undefined;
 
-    asm volatile("inw %[p],%[r]":[r]"={ax}"(res):[p]"{dx}"(port));
+    asm volatile ("inw %[p],%[r]"
+        : [r] "={ax}" (res),
+        : [p] "{dx}" (port),
+    );
     return res;
 }
 
@@ -35,6 +53,9 @@ pub inline fn inw(port: u16) u16 {
 pub inline fn inl(port: u16) u32 {
     var res: u32 = undefined;
 
-    asm volatile("inl %[p],%[r]":[r]"={eax}"(res):[p]"{dx}"(port));
+    asm volatile ("inl %[p],%[r]"
+        : [r] "={eax}" (res),
+        : [p] "{dx}" (port),
+    );
     return res;
 }

--- a/src/kernel/arch/x86-64/regs.zig
+++ b/src/kernel/arch/x86-64/regs.zig
@@ -1,6 +1,6 @@
 //! # x86-64 Registers
-//! 
-//! Provides access to various x86-64 CPU registers, Global/Interrupt Descriptor Tables (GDT/IDT). 
+//!
+//! Provides access to various x86-64 CPU registers, Global/Interrupt Descriptor Tables (GDT/IDT).
 //! It includes functions for reading/writing MSRs and saving/restoring CPU state.
 
 // Copyright (C) 2024 Konstantin Pigulevskiy (bagggage@github)
@@ -26,7 +26,7 @@ pub const IDTR = packed struct {
     base: u64 = undefined,
 
     pub fn format(self: *const IDTR, _: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {
-        try writer.print("base = 0x{x}, limit = {}", .{self.base,self.limit});
+        try writer.print("base = 0x{x}, limit = {}", .{ self.base, self.limit });
     }
 };
 
@@ -48,32 +48,7 @@ pub const EFER = packed struct {
     reserved_3: u48,
 };
 
-pub const Flags = packed struct {
-    carry: bool = false,
-    reserved_1: u1 = 1,
-    parity: bool = false,
-    reserved_2: u1 = 1,
-    aux_carry: bool = false,
-    reserved_3: u1 = 1,
-    zero: bool = false,
-    sign: bool = false,
-    trap: bool = false,
-    intr_enable: bool = false,
-    direction: bool = false,
-    overflow: bool = false,
-    io_privilege: u2 = undefined,
-    nested_task: u1 = undefined,
-    reserved_4: u1 = 0,
-    @"resume": bool = false,
-    virt_mode: bool = false,
-    align_check: bool = false,
-    virt_intr: bool = false,
-    virt_intr_pending: bool = false,
-    cpuid: bool = true,
-    reserved_5: u8 = 0,
-    aes: bool = false,
-    alt_instr_set: bool = false
-};
+pub const Flags = packed struct { carry: bool = false, reserved_1: u1 = 1, parity: bool = false, reserved_2: u1 = 1, aux_carry: bool = false, reserved_3: u1 = 1, zero: bool = false, sign: bool = false, trap: bool = false, intr_enable: bool = false, direction: bool = false, overflow: bool = false, io_privilege: u2 = undefined, nested_task: u1 = undefined, reserved_4: u1 = 0, @"resume": bool = false, virt_mode: bool = false, align_check: bool = false, virt_intr: bool = false, virt_intr_pending: bool = false, cpuid: bool = true, reserved_5: u8 = 0, aes: bool = false, alt_instr_set: bool = false };
 
 pub const ScratchRegs = extern struct {
     rax: u64 = 0,
@@ -87,14 +62,7 @@ pub const ScratchRegs = extern struct {
     r11: u64 = 0,
 };
 
-pub const CalleeRegs = extern struct {
-    rbx: u64 = 0,
-    rbp: u64 = 0,
-    r12: u64 = 0,
-    r13: u64 = 0,
-    r14: u64 = 0,
-    r15: u64 = 0
-};
+pub const CalleeRegs = extern struct { rbx: u64 = 0, rbp: u64 = 0, r12: u64 = 0, r13: u64 = 0, r14: u64 = 0, r15: u64 = 0 };
 
 pub const State = extern struct {
     callee: CalleeRegs,
@@ -103,15 +71,9 @@ pub const State = extern struct {
 
 /// Stack frame that is automatically pushed
 /// when a hardware interrupt occurs.
-pub const InterruptFrame = extern struct {
-    rip: u64 = 0,
-    cs: u64 = 0,
-    rflags: u64 = 0,
-    rsp: u64 = 0,
-    ss: u64 = 0
-};
+pub const InterruptFrame = extern struct { rip: u64 = 0, cs: u64 = 0, rflags: u64 = 0, rsp: u64 = 0, ss: u64 = 0 };
 
-/// Represents the full state of the CPU during an interrupt, including the 
+/// Represents the full state of the CPU during an interrupt, including the
 /// callee-saved registers, scratch registers, and the interrupt frame.
 pub const IntrState = extern struct {
     callee: CalleeRegs = .{},
@@ -132,7 +94,7 @@ pub const LowLevelIntrState = extern struct {
 };
 
 /// Read Model-Specific Register.
-/// 
+///
 /// - `msr_addr`: The address of the MSR to read.
 /// - Returns: The value of the MSR.
 pub inline fn getMsr(msr_addr: u32) u64 {
@@ -149,7 +111,7 @@ pub inline fn getMsr(msr_addr: u32) u64 {
 }
 
 /// Write Model-Specific Register.
-/// 
+///
 /// - `msr_addr`: The address of the MSR to write.
 /// - `value`: The value to write to the MSR.
 pub inline fn setMsr(msr_addr: u32, value: u64) void {
@@ -226,7 +188,8 @@ pub inline fn getCs() u16 {
 
 pub inline fn setGs(selector: u16) void {
     asm volatile ("mov %[res],%%gs"
-        :: [res] "r" (selector),
+        :
+        : [res] "r" (selector),
     );
 }
 
@@ -238,42 +201,36 @@ pub inline fn getSs() u16 {
 
 pub inline fn setSs(selector: u16) void {
     asm volatile ("mov %[res],%%ss"
-        :: [res] "r" (selector),
+        :
+        : [res] "r" (selector),
     );
 }
 
 pub inline fn getFlags() Flags {
-    return asm volatile(
+    return asm volatile (
         \\pushfq
         \\pop %rax
-        : [out] "={rax}" (-> Flags)
+        : [out] "={rax}" (-> Flags),
         :
-        : "memory"
+        : .{ .memory = true }
     );
 }
 
 pub inline fn swapgs() void {
-    asm volatile("swapgs");
+    asm volatile ("swapgs");
 }
 
 pub inline fn swapStackToKernel() void {
-    asm volatile(std.fmt.comptimePrint(
-        \\ movq %rsp, %gs:{}
-        \\ movq %gs:{}, %rsp
-        , .{
-            @offsetOf(smp.LocalData, "current_sp"),
-            @offsetOf(smp.LocalData, "kernel_sp")
-        }
-    ));
+    asm volatile (std.fmt.comptimePrint(
+            \\ movq %rsp, %gs:{}
+            \\ movq %gs:{}, %rsp
+        , .{ @offsetOf(smp.LocalData, "current_sp"), @offsetOf(smp.LocalData, "kernel_sp") }));
 }
 
 pub inline fn swapStackToUser() void {
-    asm volatile(std.fmt.comptimePrint(
-        \\ movq %gs:{}, %rsp
-        , .{
-            @offsetOf(smp.LocalData, "current_sp")
-        }
-    ));
+    asm volatile (std.fmt.comptimePrint(
+            \\ movq %gs:{}, %rsp
+        , .{@offsetOf(smp.LocalData, "current_sp")}));
 }
 
 pub inline fn saveCallerRegs() void {
@@ -347,31 +304,31 @@ pub inline fn getStack() usize {
 
 pub inline fn setStack(stack: usize) void {
     asm volatile ("mov %[res],%%rsp"
-        :: [res] "r" (stack),
+        :
+        : [res] "r" (stack),
     );
 }
 
 pub inline fn getIdtr() IDTR {
     var idtr: IDTR = undefined;
-    asm volatile (
-        "sidt %[reg]"
-        :[reg] "=memory" (idtr)
+    asm volatile ("sidt %[reg]"
+        : [reg] "=memory" (idtr),
     );
 
     return idtr;
 }
 
 pub inline fn setIdtr(idtr: IDTR) void {
-    asm volatile (
-        "lidt %[reg]"
-        ::[reg] "memory" (idtr),
+    asm volatile ("lidt %[reg]"
+        :
+        : [reg] "memory" (idtr),
     );
 }
 
 pub inline fn setTss(tss: u16) void {
-    asm volatile (
-        "ltr %[seg]"
-        ::[seg] "r" (tss)
+    asm volatile ("ltr %[seg]"
+        :
+        : [seg] "r" (tss),
     );
 }
 
@@ -379,21 +336,24 @@ pub inline fn getTsc() u64 {
     var hi: u32 = undefined;
     var lo: u32 = undefined;
 
-    asm volatile ("rdtsc" : [hi]"={edx}"(hi),[lo]"={eax}"(lo));
+    asm volatile ("rdtsc"
+        : [hi] "={edx}" (hi),
+          [lo] "={eax}" (lo),
+    );
 
     return (@as(u64, hi) << 32) | lo;
 }
 
 pub inline fn stackAlloc(comptime items_num: comptime_int) void {
-    asm volatile (
-        "sub %[size],%rsp"
-        ::[size] "i" (items_num * @sizeOf(usize))
+    asm volatile ("sub %[size],%rsp"
+        :
+        : [size] "i" (items_num * @sizeOf(usize)),
     );
 }
 
 pub inline fn stackFree(comptime items_num: comptime_int) void {
-    asm volatile (
-        "add %[size],%rsp"
-        ::[size] "i" (items_num * @sizeOf(usize))
+    asm volatile ("add %[size],%rsp"
+        :
+        : [size] "i" (items_num * @sizeOf(usize)),
     );
 }

--- a/src/kernel/arch/x86-64/time.zig
+++ b/src/kernel/arch/x86-64/time.zig
@@ -49,17 +49,20 @@ pub inline fn getSysTimer() ?*Timer {
 }
 
 fn timerIntrRoutin() callconv(.naked) noreturn {
-    asm volatile("call isr.entry");
-    defer asm volatile("jmp isr.exit");
+    asm volatile ("call isr.entry");
+    defer asm volatile ("jmp isr.exit");
 
     const local = arch.getCpuLocalData();
-    asm volatile("push %[local]" :: [local] "r" (local));
+    asm volatile ("push %[local]"
+        :
+        : [local] "r" (local),
+    );
 
     dev.intr.handlerEnter(local);
-    defer asm volatile(
+    defer asm volatile (
         \\ pop %rdi
         \\ call intrHandlerExit
     );
 
-    asm volatile("call timerIntrHandler");
+    asm volatile ("call timerIntrHandler");
 }

--- a/src/kernel/arch/x86-64/vm.zig
+++ b/src/kernel/arch/x86-64/vm.zig
@@ -95,9 +95,13 @@ pub fn init() vm.Error!void {
     pt_oma = try vm.ObjectAllocator.initRaw(@sizeOf(PageTable), oma_pool, pt_pool_pages);
 }
 
-pub inline fn lmaEnd() usize { return lma_end; }
+pub inline fn lmaEnd() usize {
+    return lma_end;
+}
 
-pub inline fn heapStart() usize { return heap_start; }
+pub inline fn heapStart() usize {
+    return heap_start;
+}
 
 pub inline fn isUserVirtAddr(virt: usize) bool {
     return (virt & 0xFFFF_0000_0000_0000) == 0;
@@ -416,11 +420,11 @@ pub fn unmap(virt: usize, pages: u32, page_table: *PageTable) void {
             if (pte[0].size == 1) {
                 // Determine if this is a 1GB or 2MB page
                 const is_1gb = (pt_idx == 1);
-                pages_step = if (is_1gb) 
-                    (utils.gb_size / page_size) 
-                else 
+                pages_step = if (is_1gb)
+                    (utils.gb_size / page_size)
+                else
                     pages_per_2mb;
-                
+
                 entries_to_unmap = 1; // Large page covers all remaining entries
             }
 
@@ -461,7 +465,7 @@ fn correctMmapFlags(flags: vm.MapFlags, virt: usize, phys: usize, pages: u32) vm
     if (flags.large) {
         if (pages < pages_per_2mb or
             (virt % (2 * utils.mb_size) != 0 or
-            phys % (2 * utils.mb_size) != 0)) result.large = false;
+                phys % (2 * utils.mb_size) != 0)) result.large = false;
     }
 
     return result;

--- a/src/kernel/dev/Device.zig
+++ b/src/kernel/dev/Device.zig
@@ -9,8 +9,17 @@ const dev = @import("../dev.zig");
 const Driver = @import("Driver.zig");
 const log = std.log.scoped(.Device);
 const utils = @import("../utils.zig");
+const vm = @import("../vm.zig");
 
 const Self = @This();
+
+pub const List = utils.List;
+pub const Node = List.Node;
+
+pub const alloc_config: vm.obj.AllocatorConfig = .{
+    .allocator = .safe_oma,
+    .capacity = 64
+};
 
 name: dev.Name = .{},
 bus: *Bus,
@@ -18,6 +27,29 @@ bus: *Bus,
 driver: ?*const Driver,
 driver_data: utils.AnyData,
 
+node: Node = .{},
+
+pub fn new(name: dev.Name, bus: *Bus, driver: ?*const Driver, data: ?*anyopaque) ?*Self {
+    const self = vm.obj.new(Self) orelse return null;
+    self.* = .{
+        .name = name,
+        .bus = bus,
+        .driver = driver,
+        .driver_data = utils.AnyData.from(data),
+    };
+
+    return self;
+}
+
+pub fn delete(self: *Self) void {
+    self.deinit();
+    vm.obj.free(Self, self);
+}
+
 pub inline fn deinit(self: *Self) void {
     self.name.deinit();
+}
+
+pub inline fn fromNode(node: *Node) *Self {
+    return @fieldParentPtr("node", node);
 }

--- a/src/kernel/dev/Driver.zig
+++ b/src/kernel/dev/Driver.zig
@@ -9,6 +9,9 @@ const utils = @import("../utils.zig");
 
 const Self = @This();
 
+pub const List = utils.List;
+pub const Node = List.Node;
+
 pub const Operations = struct {
     pub const ProbeResult = enum {
         missmatch,
@@ -31,17 +34,16 @@ pub const Operations = struct {
 
 name: []const u8,
 bus: *Bus = undefined,
+node: Node = .{},
 ops: Operations,
 
 pub fn init(
     comptime name: []const u8,
     comptime ops: Operations
-) dev.DriverNode {
+) Self {
     return .{
-        .data = .{
-            .name = name,
-            .ops = ops,
-        }
+        .name = name,
+        .ops = ops,
     };
 }
 
@@ -62,4 +64,8 @@ pub inline fn removeDevice(self: *const Self, device: *Device) void {
 
 pub inline fn addDevice(self: *const Self, name: dev.Name, data: ?*anyopaque) !*Device {
     return self.bus.addDevice(name, self, data) orelse return error.NoMemory;
+}
+
+pub inline fn fromNode(node: *Node) *Self {
+    return @fieldParentPtr("node", node);
 }

--- a/src/kernel/dev/drivers/blk/nvme.zig
+++ b/src/kernel/dev/drivers/blk/nvme.zig
@@ -216,7 +216,7 @@ const Namespace = struct {
         self.base.deinit();
     }
 
-    pub fn handleIo(self: *Drive, request: *const Drive.IoRequest) bool {
+    pub fn handleIo(self: *Drive, request: *const Drive.io.Request) bool {
         const ns = &@as(*NamespaceDrive, @ptrCast(self)).derived;
         const pages = request.lba_num / (vm.page_size / self.lba_size);
         const prp1 = @intFromPtr(vm.getPhysLma(request.lma_buf));

--- a/src/kernel/dev/drivers/timer/acpi_timer.zig
+++ b/src/kernel/dev/drivers/timer/acpi_timer.zig
@@ -35,7 +35,7 @@ inline fn isAvailable() bool {
 }
 
 fn initDevice(self: *const dev.Driver) !void {
-    const device = try self.addDevice(dev.nameOf(device_name), null);
+    const device = try self.addDevice(dev.Name.init(device_name), null);
     errdefer dev.removeDevice(device);
 
     try initTimer();

--- a/src/kernel/dev/drivers/uart.zig
+++ b/src/kernel/dev/drivers/uart.zig
@@ -98,5 +98,5 @@ fn initDevice(self: *const dev.Driver) !void {
     initPort();
     if (!testPort()) return; // COM port is unavailable.
 
-    device = try self.addDevice(dev.nameOf("UART RS-232"), null);
+    device = try self.addDevice(dev.Name.init("UART RS-232"), null);
 }

--- a/src/kernel/dev/stds/pci.zig
+++ b/src/kernel/dev/stds/pci.zig
@@ -93,13 +93,13 @@ pub const Device = struct {
     }
 
     pub inline fn from(device: *const dev.Device) *Device {
-        std.debug.assert(device.bus == &bus.data);
+        std.debug.assert(device.bus == &bus);
         return device.driver_data.as(Device) orelse unreachable;
     }
 };
 
 pub const Driver = struct {
-    base: dev.DriverNode,
+    base: dev.Driver,
     match_id: Id,
 
     pub fn init(
@@ -114,9 +114,7 @@ pub const Driver = struct {
     }
 
     pub inline fn from(driver: *const dev.Driver) *const Driver {
-        const driver_node: *const dev.DriverNode = @fieldParentPtr("data", driver);
-        const pci_driver: *const Driver = @fieldParentPtr("base", driver_node);
-        return pci_driver;
+        return @fieldParentPtr("base", driver);
     }
 };
 
@@ -199,8 +197,8 @@ fn enumDevice(seg_idx: u16, bus_idx: u8, dev_idx: u8, func_idx: u8) !bool {
 
     errdefer dev_oma.free(pci_dev);
 
-    const device = bus.data.addDevice(
-        try dev.nameFmt(
+    const device = bus.addDevice(
+        try dev.Name.print(
             "{x:0>4}:{x:0>2}:{x:0>2}.{}",
             .{seg_idx,bus_idx,dev_idx,func_idx}
         ), null, pci_dev
@@ -208,7 +206,7 @@ fn enumDevice(seg_idx: u16, bus_idx: u8, dev_idx: u8, func_idx: u8) !bool {
 
     pci_dev.device = device;
 
-    log.debug("device: {}: VEN_ID 0x{x:0>4} : DEV_ID 0x{x:0>4}", .{
+    log.debug("device: {f}: VEN_ID 0x{x:0>4} : DEV_ID 0x{x:0>4}", .{
         device.name, vendor_id, pci_dev.id.device_id
     });
 

--- a/src/kernel/sched/Scheduler.zig
+++ b/src/kernel/sched/Scheduler.zig
@@ -36,15 +36,15 @@ const TaskQueue = struct {
         const priority = task.stats.getPriority();
         if (priority < self.last_min) self.last_min = priority;
 
-        self.lists[priority].append(task.asNode());
+        self.lists[priority].append(&task.node);
         self.size +%= 1;
     }
 
     pub fn pop(self: *TaskQueue) ?*Task {
         for (self.lists[self.last_min..len]) |*list| {
-            if (list.popFirst()) |node| {
+            if (list.popFirst()) |n| {
                 self.size -%= 1;
-                return &node.data;
+                return Task.fromNode(n);
             }
 
             self.last_min += 1;
@@ -55,7 +55,7 @@ const TaskQueue = struct {
 
     pub fn remove(self: *TaskQueue, task: *Task) void {
         const priority = task.stats.getPriority();
-        self.lists[priority].remove(task.asNode());
+        self.lists[priority].remove(&task.node);
     }
 };
 
@@ -279,11 +279,11 @@ pub fn tick(self: *Self) void {
     }
 }
 
-pub fn initWait(self: *Self) WaitQueue.QNode {
+pub fn initWait(self: *Self) WaitQueue.Entry {
     const task = self.current_task;
     task.stats.state = .waiting;
 
-    return WaitQueue.initEntry(
+    return WaitQueue.Entry.init(
         task,
         sys.time.getFastTimestamp()
     );

--- a/src/kernel/sched/Task.zig
+++ b/src/kernel/sched/Task.zig
@@ -13,7 +13,7 @@ const vm = @import("../vm.zig");
 
 pub const Self = @This();
 
-pub const List = utils.List(Self);
+pub const List = utils.List;
 pub const Node = List.Node;
 
 pub const State = enum(u8) {
@@ -131,7 +131,7 @@ pub const KernelSpecific = struct {
 
 /// User task specific data.
 pub const UserSpecific = struct {
-    pub const UList = utils.SList(void);
+    pub const UList = utils.SList;
     pub const UNode = UList.Node;
 
     process: *sys.Process,
@@ -144,12 +144,12 @@ pub const UserSpecific = struct {
 pub const alloc_config: vm.obj.AllocatorConfig = .{
     .allocator = .safe_oma,
     .capacity = 128,
-    .wrapper = .listNode(Node)
 };
 
 stats: Stats = .{},
 /// Arch-specific context used for context switching.
 context: arch.Context,
+node: Node = .{},
 
 /// Kernel stack is not appear as
 /// map unit and hidden from userspace,
@@ -163,6 +163,6 @@ spec: union {
     user: UserSpecific,
 },
 
-pub inline fn asNode(self: *Self) *Node {
-    return @fieldParentPtr("data", self);
+pub inline fn fromNode(node: *Node) *Self {
+    return @fieldParentPtr("node", node);
 }

--- a/src/kernel/start.zig
+++ b/src/kernel/start.zig
@@ -10,6 +10,6 @@ extern fn main() noreturn;
 /// The `_start` function delegates to the `startImpl` function, defined in the architecture-specific 
 /// `utils.zig` module. The `startImpl` is responsible for setting up the initial CPU state 
 /// and then jumping to the `main` function.
-pub export fn _start() callconv(.Naked) noreturn {
+pub export fn _start() callconv(.naked) noreturn {
     @import("utils.zig").arch.startImpl();
 }

--- a/src/kernel/sys/MapUnit.zig
+++ b/src/kernel/sys/MapUnit.zig
@@ -11,7 +11,7 @@ const vm = @import("../vm.zig");
 
 const Self = @This();
 
-pub const List = utils.SList(Self);
+pub const List = utils.SList;
 pub const Node = List.Node;
 
 pub const Flags = packed struct {
@@ -49,8 +49,7 @@ pub const PageHandle = struct {
 
 pub const alloc_config: vm.obj.AllocatorConfig = .{
     .allocator = .safe_oma,
-    .capacity = 256,
-    .wrapper = .listNode(Node)
+    .capacity = 256
 };
 
 pub const max_pages = Page.max_index + vm.PageAllocator.max_alloc_pages;
@@ -70,6 +69,7 @@ page_capacity: u32,
 ops: *const Operations = &default_ops,
 flags: Flags,
 
+node: Node = .{},
 rb_node: rb.Node = .{},
 
 pub fn init(
@@ -91,8 +91,8 @@ pub inline fn deinit(self: *Self) void {
     self.region.deinit(self.isAnonymous());
 }
 
-pub inline fn asNode(self: *Self) *Node {
-    return @fieldParentPtr("data", self);
+pub inline fn fromNode(node: *Node) *Self {
+    return @fieldParentPtr("node", node);
 }
 
 pub inline fn fromRbNode(node: *rb.Node) *Self {
@@ -128,18 +128,20 @@ pub fn unmapRegion(self: *Self, page_offset: u32, pages: u32, pt: *vm.PageTable)
 
     if (self.isAnonymous()) {
         while (node) |n| {
-            n.data.unmap(self.base(), pt);
-            vm.PageAllocator.free(n.data.getPhysBase(), n.data.rank);
+            const page = Page.fromNode(n);
+            page.unmap(self.base(), pt);
+            vm.PageAllocator.free(page.getPhysBase(), page.dim.rank);
 
             node = n.next;
-            vm.obj.free(Page, &n.data);
+            vm.obj.free(Page, page);
         }
     } else {
         while (node) |n| {
-            n.data.unmap(self.base(), pt);
+            const page = Page.fromNode(n);
+            page.unmap(self.base(), pt);
 
             node = n.next;
-            vm.obj.free(Page, &n.data);
+            vm.obj.free(Page, page);
         }
     }
 }
@@ -210,7 +212,7 @@ fn detachPagesTo(self: *Self, page_base: u32, page_len: u32, list: *Page.List) !
     while (self.findPage(page_base, page_len)) |h| {
         const col_base = h.page.base;
         const col_len = h.page.pagesNum();
-        const col_top = h.page.idx + col_len;
+        const col_top = h.page.dim.idx + col_len;
 
         // Shrink or divide this physical region if needed.
         if (page_base > col_base) {
@@ -232,7 +234,7 @@ fn detachPagesTo(self: *Self, page_base: u32, page_len: u32, list: *Page.List) !
 }
 
 fn detachPage(self: *Self, list: *Page.List, handle: *const PageHandle) void {
-    const node = handle.page.asNode();
+    const node = &handle.page.node;
 
     // Remove page from the list.
     if (handle.prev) |p| {
@@ -250,20 +252,15 @@ fn findPage(self: *Self, page_base: u32, page_len: u32) ?PageHandle {
     var prev: ?*Page.Node = null;
     var node: ?*Page.Node = self.region.page_list.first;
 
-    while (node) |n| {
-        const n_base: u32 = n.data.idx;
-        const n_len: u32 = n.data.pagesNum();
+    while (node) |n| : ({prev = node; node = n.next;}) {
+        const page = Page.fromNode(n);
+        const n_base: u32 = page.dim.idx;
+        const n_len: u32 = page.pagesNum();
         const n_top: u32 = n_base + n_len;
 
         if (page_base < n_top and n_base < page_top) {
-            return .{
-                .prev = prev,
-                .page = &n.data,
-            };
+            return .{ .prev = prev, .page = page };
         }
-
-        prev = node;
-        node = n.next;
     }
 
     return null;
@@ -271,16 +268,16 @@ fn findPage(self: *Self, page_base: u32, page_len: u32) ?PageHandle {
 
 fn shrinkPageTop(list: *Page.List, page: *Page, new_top_idx: u32) !void {
     const page_len = page.pagesNum();
-    const page_top_idx = page_len + page.idx;
+    const page_top_idx = page_len + page.dim.idx;
     const detach_len = page_top_idx - new_top_idx;
     const page_new_len = page_len - detach_len;
     const detach_base = page.base + page_new_len;
 
-    const node_dump = page.asNode().*;
+    const page_dump = page.*;
     const list_end = list.first;
 
     // Free new pages on error.
-    var dummy_list: Page.List = .{ .first = page.asNode() };
+    var dummy_list: Page.List = .{ .first = &page.node };
 
     try buildPage( // Detached pages
         list, detach_base,
@@ -288,31 +285,30 @@ fn shrinkPageTop(list: *Page.List, page: *Page, new_top_idx: u32) !void {
     );
 
     errdefer freePageList(list, list_end);
-    errdefer page.asNode().* = node_dump;
+    errdefer page.* = page_dump;
 
     try buildPage( // Rebuilded pages
         &dummy_list, page.base,
-        page.idx, page_len, true
+        page.dim.idx, page_len, true
     );
 }
 
 fn shrinkPageBottom(list: *Page.List, page: *Page, new_idx: u32) !void {
-    const detach_len = new_idx - page.idx;
+    const detach_len = new_idx - page.dim.idx;
     const page_new_base = page.base + detach_len;
     const page_new_len = page.pagesNum() - detach_len;
 
-    const node_dump = page.asNode().*;
+    const page_dump = page.*;
     const list_end = list.first;
 
-    var dummy_list: Page.List = .{ .first = page.asNode() };
-
+    var dummy_list: Page.List = .{ .first = &page.node };
     try buildPage( // Detached pages.
         list, page.base,
-        page.idx, detach_len, false
+        page.dim.idx, detach_len, false
     );
 
     errdefer freePageList(list, list_end);
-    errdefer page.asNode().* = node_dump;
+    errdefer page.* = page_dump;
 
     try buildPage( // Rebuilded pages.
         &dummy_list, page_new_base,
@@ -321,24 +317,24 @@ fn shrinkPageBottom(list: *Page.List, page: *Page, new_idx: u32) !void {
 }
 
 fn dividePages(list: *Page.List, page: *Page, div_idx: u32, div_top_idx: u32) !void {
-    const page_new_len = div_idx - page.idx;
+    const page_new_len = div_idx - page.dim.idx;
     const div_len = div_top_idx - div_idx;
     const div_base = page.base + page_new_len;
     const page_next_len = page.pagesNum() - page_new_len - div_len;
     const page_next_base = page.base + page_new_len + div_len;
 
-    const node_dump = page.asNode().*;
-    const dummy_end = page.asNode().next;
-    var dummy_list: Page.List = .{ .first = page.asNode() };
+    const page_dump = page.*;
+    const dummy_end = page.node.next;
+    var dummy_list: Page.List = .{ .first = &page.node };
 
-    errdefer page.asNode().* = node_dump;
+    errdefer page.* = page_dump;
 
     try buildPage( // Build left part of the page.
         &dummy_list, page.base,
-        page.idx, page_new_len, true
+        page.dim.idx, page_new_len, true
     );
     errdefer {
-        var clean_list: Page.List = .{ .first = page.asNode().next };
+        var clean_list: Page.List = .{ .first = page.node.next };
         freePageList(&clean_list, dummy_end);
     }
 
@@ -376,7 +372,7 @@ fn buildPage(
     while (temp_len > 0) {
         const new_page =
             if (reuse_first and temp_base == phys_base)
-                &list.first.?.data
+                Page.fromNode(list.first.?)
             else
                 (vm.obj.new(Page) orelse return error.NoMemory);
 
@@ -390,13 +386,15 @@ fn buildPage(
 
         new_page.* = .{
             .base = temp_base,
-            .idx = @truncate(temp_idx),
-            .rank = temp_rank
+            .dim = .{
+                .idx = @truncate(temp_idx),
+                .rank = temp_rank
+            },
         };
 
         // Insert new page node after current page.
         if ((comptime !reuse_first) or temp_base != phys_base) {
-            const new_node = new_page.asNode();
+            const new_node = &new_page.node;
 
             if (insert_after)
                 list.first.?.insertAfter(new_node)
@@ -415,6 +413,6 @@ fn freePageList(list: *Page.List, end: ?*Page.Node) void {
         if (n == end) break;
 
         list.first = n.next;
-        vm.obj.free(Page, &n.data);
+        vm.obj.free(Page, Page.fromNode(n));
     }
 }

--- a/src/kernel/utils/Bitmap.zig
+++ b/src/kernel/utils/Bitmap.zig
@@ -55,12 +55,12 @@ pub fn rfind(self: *Self, comptime is_setted: bool) ?usize {
     var byte_idx = self.bits.len;
 
     while (byte_idx > 0) {
-        byte_idx -= 1;
+        byte_idx -%= 1;
 
         const byte = self.bits[byte_idx];
         if (byte == byte_val) continue;
 
-        return (byte_idx * utils.byte_size) + if (comptime is_setted) @ctz(byte) else @ctz(~byte);
+        return (byte_idx *% utils.byte_size) + if (comptime is_setted) @ctz(byte) else @ctz(~byte);
     }
 
     return null;

--- a/src/kernel/vfs/File.zig
+++ b/src/kernel/vfs/File.zig
@@ -29,7 +29,6 @@ pub const Operations = struct {
 
 pub const alloc_config: vm.obj.AllocatorConfig = .{
     .allocator = .safe_oma,
-    .wrapper = .none,
     .capacity = 128,
 };
 

--- a/src/kernel/vfs/drivers/devfs.zig
+++ b/src/kernel/vfs/drivers/devfs.zig
@@ -52,21 +52,16 @@ pub const Region = struct {
 };
 
 pub const DevFile = struct {
-    const List = utils.SList(void);
+    const List = utils.SList;
     const Node = List.Node;
 
     name: dev.Name,
-
     num: DevNum,
 
     fops: *const vfs.File.Operations,
     data: utils.AnyData = .{},
 
-    node: Node = .{ .data = undefined },
-
-    pub inline fn asNode(self: *DevFile) *Node {
-        return &self.node;
-    }
+    node: Node = .{},
 
     pub inline fn fromNode(node: *Node) *DevFile {
         return @fieldParentPtr("node", node);
@@ -108,7 +103,7 @@ pub const BlockDev = struct {
 };
 
 const DevList = struct {
-    list: DevFile.List,
+    list: DevFile.List = .{},
     max_no: u16,
 
     lock: utils.Spinlock = .{},

--- a/src/kernel/vfs/internals.zig
+++ b/src/kernel/vfs/internals.zig
@@ -45,17 +45,17 @@ pub const dentry_ops = opaque {
 
     pub const debug = opaque {
         pub fn lookup(dentry: *const Dentry, _: []const u8) ?*Dentry {
-            std.log.warn("{}: 'lookup' is not implemented", .{dentry.path()});
+            std.log.warn("{f}: 'lookup' is not implemented", .{dentry.path()});
             return null;
         }
 
         pub fn makeDirectory(dentry: *const Dentry, _: *Dentry) Error!void {
-            std.log.warn("{}: 'makeDirectory' is not implemented", .{dentry.path()});
+            std.log.warn("{f}: 'makeDirectory' is not implemented", .{dentry.path()});
             return error.BadOperation;
         }
 
         pub fn createFile(dentry: *const Dentry, _: *Dentry) Error!void {
-            std.log.warn("{}: 'createFile' is not implemented", .{dentry.path()});
+            std.log.warn("{f}: 'createFile' is not implemented", .{dentry.path()});
             return error.BadOperation;
         }
 
@@ -64,12 +64,12 @@ pub const dentry_ops = opaque {
         }
 
         pub fn open(dentry: *const Dentry, _: *File) Error!void {
-            std.log.warn("{}: 'open' is not implemented", .{dentry.path()});
+            std.log.warn("{f}: 'open' is not implemented", .{dentry.path()});
             return error.BadOperation;
         }
 
         pub fn close(dentry: *const Dentry, _: *File) void {
-            std.log.warn("{}: 'close' is not implemented", .{dentry.path()});
+            std.log.warn("{f}: 'close' is not implemented", .{dentry.path()});
         }
 
         pub const ops: Dentry.Operations = .{

--- a/src/kernel/video/terminal.zig
+++ b/src/kernel/video/terminal.zig
@@ -186,7 +186,7 @@ pub fn write(str: []const u8) void {
             i += handleEscapeSequence(str[i..]) - 1;
         } else if (std.ascii.isControl(char)) {
             handleControlChar(char);
-        } else if (std.ascii.isASCII(char)) {
+        } else if (std.ascii.isAscii(char)) {
             cacheChar(char);
 
             text_output.drawChar(char, curr_col, cursor.row, cursor.col);

--- a/src/kernel/vm.zig
+++ b/src/kernel/vm.zig
@@ -380,7 +380,7 @@ pub fn pageFaultHandler(addr: usize, cause: FaultCause, userspace: bool) bool {
     }
 
     log.warn(
-        \\{raw-log}Page Fault (CPU {}) - {}: 
+        \\Page Fault (CPU {}) - {f}: 
         \\ address: 0x{x:.>16}; cause: {s}
         \\ userspace: {}
         ++ "\n"

--- a/src/kernel/vm/UniversalAllocator.zig
+++ b/src/kernel/vm/UniversalAllocator.zig
@@ -71,12 +71,12 @@ const HugeNode = HugeTree.Node;
 
 /// A fixed-size array of object allocators (`vm.ObjectAllocator`),
 /// used for managing small memory blocks.
-var oma_pool: [oma_pool_len]vm.ObjectAllocator = init_oma_pool();
+var oma_pool: [oma_pool_len]vm.ObjectAllocator = initOmaPool();
 
 /// An object allocator dedicated to managing nodes within the `HugeTree`.
-var huge_oma = vm.ObjectAllocator.init(HugeNode);
+var huge_oma: vm.ObjectAllocator = .init(HugeNode);
 /// The binary tree that manages all large memory block allocations.
-var huge_alloc_tree = HugeTree{};
+var huge_alloc_tree: HugeTree = .{};
 
 /// Allocates a block of memory of the specified `size`.
 /// 
@@ -86,7 +86,6 @@ var huge_alloc_tree = HugeTree{};
 /// or `null` if the allocation fails.
 pub inline fn alloc(size: usize) ?*anyopaque {
     std.debug.assert(size > 0 and size < (vm.PageAllocator.max_alloc_pages * vm.page_size));
-
     return if (size <= max_small_size) allocSmall(@truncate(size)) else allocHuge(@truncate(size));
 }
 
@@ -171,7 +170,7 @@ fn allocHuge(size: u32) ?*anyopaque {
 /// This function is called only once in compile time.
 /// 
 /// - Returns: A fixed-size array of initialized `vm.ObjectAllocator` instances.
-fn init_oma_pool() [oma_pool_len]vm.ObjectAllocator {
+fn initOmaPool() [oma_pool_len]vm.ObjectAllocator {
     var result: [oma_pool_len]vm.ObjectAllocator = undefined;
 
     const min_rank = std.math.log2(min_size);
@@ -184,7 +183,7 @@ fn init_oma_pool() [oma_pool_len]vm.ObjectAllocator {
         const pages_num = std.math.divCeil(u32, size * oma_min_capacity, vm.page_size) catch unreachable;
         const pages = @as(u32, 1) << @truncate(std.math.log2_int_ceil(u32, pages_num));
 
-        result[i] = vm.ObjectAllocator.initSized(size, pages);
+        result[i] = .initSized(size, pages);
     }
 
     return result;


### PR DESCRIPTION
- Update Zig version in `build.zig.zon`.
- Update `build.zig`.
- Fix all linked lists: now node structure is embedded into a parent struct.
- Fix calling conventions names: now starts from a lower case letter.
- Fix inline assembler clobbers.
- Remove `usingnamespace` keyword, instead declarations are directly imported and marked as public.
- `std.BoundedArray`, replaced with a buffer + `std.ArrayList`, or just with a buffer.
- Logger is refactored and optimezed for the new `std.Io` interface.
- Formatting functions are changed to be compatible with the new `std.Io` interface.
- Build tools: `zip` and `dbg-make` are also moved to the new `std.Io` interface. (`tar` is still using deprecated `std.io`)
- Due to a chance, some code is refactored and code base is unified. Now code-style is almost the same for the entire kernel.