### PR TITLE
fix: update url for uacpi

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -13,8 +13,8 @@
             .lazy = true,
         },
         .uacpi = .{
-            .url = "git+https://github.com/uACPI/uACPI#for-5.0",
-            .hash = "N-V-__8AAPspFACnNZvL7Qat26yH6jT2ND5XvcG_F18fXzSF",
+            .url = "git+https://github.com/uACPI/uACPI#5.0.0",
+            .hash = "N-V-__8AAPJOKQCmvBm20OcVV9z7cnNcWOy4bfb9d-p-iJr9",
         },
     },
 


### PR DESCRIPTION
Update the uACPI dependency from the missing `for-5.0` ref to the existing `5.0.0` tag and refresh the Zig package hash.

Verified with `zig build docs`.